### PR TITLE
Fix docker containers

### DIFF
--- a/agora/Dockerfile
+++ b/agora/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:2.7.15
 
 ADD requirements.txt /srv/agora/requirements.txt
 ADD requirements_dev.txt /srv/agora/requirements_dev.txt

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:8
 
-RUN npm install --global yarn
-
 ADD . /srv/agora/ui
 WORKDIR /srv/agora/ui
 


### PR DESCRIPTION
UI:
   Removed yarn installation
   The latest node:8 base image includes yarn by default so it throws an error when we try to install it
Backend:
   Use python:2.7.15 base image
   The previous image used the latest sqlite library which has a known bug when we try to run loaddata
   See issue here https://code.djangoproject.com/ticket/29182